### PR TITLE
fix unexpected end of stream handling in WebSocketReceiver

### DIFF
--- a/library/src/main/java/ibt/ortc/plugins/websocket/WebSocketReceiver.java
+++ b/library/src/main/java/ibt/ortc/plugins/websocket/WebSocketReceiver.java
@@ -60,11 +60,11 @@ public class WebSocketReceiver
 					}
 					messageBytes.clear();
 				}
-				else if (frameStart == true){
-					messageBytes.add((byte)b);
-				}
 				else if (b == -1) {
 					handleError();
+				}
+				else if (frameStart == true) {
+					messageBytes.add((byte)b);
 				}
 			}
 			catch (IOException ioe) {


### PR DESCRIPTION
Don't eat all memory ~~. We got a lot of crash logs when we got 0x00, and then input stream ended.
